### PR TITLE
Feat level design

### DIFF
--- a/Assets/Prefabs/Map/TestMap01.prefab
+++ b/Assets/Prefabs/Map/TestMap01.prefab
@@ -111,7 +111,7 @@ Transform:
   m_GameObject: {fileID: 179182669712800415}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -101.48, y: 2.2500002, z: 0}
+  m_LocalPosition: {x: -101.88, y: 2.2600002, z: 0}
   m_LocalScale: {x: 30, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1232,7 +1232,7 @@ Transform:
   m_GameObject: {fileID: 2625192080523300248}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: -161.71, y: 6.73, z: 0}
+  m_LocalPosition: {x: -163.27, y: 6.807825, z: 0}
   m_LocalScale: {x: 20, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1549,6 +1549,266 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!1 &3251034594429208176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7505786116864008801}
+  - component: {fileID: 8472971010085569785}
+  - component: {fileID: 6313622330633433463}
+  m_Layer: 6
+  m_Name: Ground (19)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7505786116864008801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3251034594429208176}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -30.26, y: -3.5, z: 0}
+  m_LocalScale: {x: 30, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 333442906963005718}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8472971010085569785
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3251034594429208176}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.68235296}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &6313622330633433463
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3251034594429208176}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!1 &3736209987169914732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8432297499577191576}
+  - component: {fileID: 3524078054362779599}
+  - component: {fileID: 8509808167661627750}
+  m_Layer: 6
+  m_Name: Ground (20)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8432297499577191576
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3736209987169914732}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 32.78, y: -3.5, z: 0}
+  m_LocalScale: {x: 35, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 333442906963005718}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3524078054362779599
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3736209987169914732}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.68235296}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &8509808167661627750
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3736209987169914732}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &3754919812664366173
 GameObject:
   m_ObjectHideFlags: 0
@@ -1576,7 +1836,7 @@ Transform:
   m_GameObject: {fileID: 3754919812664366173}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.31077364, w: 0.950484}
-  m_LocalPosition: {x: -118.67, y: 0.04, z: 0}
+  m_LocalPosition: {x: -119.51999, y: 0.307825, z: 0}
   m_LocalScale: {x: 7, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2180,8 +2440,8 @@ Transform:
   m_GameObject: {fileID: 5153800173259658060}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 129.6, y: -15.98, z: 0}
-  m_LocalScale: {x: 40, y: 1, z: 1}
+  m_LocalPosition: {x: 130.16, y: -15.98, z: 0}
+  m_LocalScale: {x: 39, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 333442906963005718}
@@ -2608,7 +2868,7 @@ Transform:
   m_GameObject: {fileID: 6205447580898476151}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.3290309, w: 0.9443192}
-  m_LocalPosition: {x: -84.85, y: 0.93000007, z: 0}
+  m_LocalPosition: {x: -85.69, y: 1.14, z: 0}
   m_LocalScale: {x: 5, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2871,6 +3131,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1272783461418719506}
+  - {fileID: 8432297499577191576}
+  - {fileID: 7505786116864008801}
   - {fileID: 8654860786822622717}
   - {fileID: 274104877630003262}
   - {fileID: 351816629313966716}
@@ -3061,7 +3323,7 @@ Transform:
   m_GameObject: {fileID: 6487148514301080552}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -141.31001, y: -1.9699999, z: 0}
+  m_LocalPosition: {x: -142.87001, y: -1.892175, z: 0}
   m_LocalScale: {x: 40, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3322,7 +3584,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -3.5, z: 0}
-  m_LocalScale: {x: 100, y: 1, z: 1}
+  m_LocalScale: {x: 30, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 333442906963005718}
@@ -3711,8 +3973,8 @@ Transform:
   m_GameObject: {fileID: 7954502055085402004}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91.14, y: -10.25, z: 0}
-  m_LocalScale: {x: 30, y: 1, z: 1}
+  m_LocalPosition: {x: 91.74, y: -10.25, z: 0}
+  m_LocalScale: {x: 28, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 333442906963005718}
@@ -3841,8 +4103,8 @@ Transform:
   m_GameObject: {fileID: 8208742501764298632}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -57.49, y: -3.5, z: 0}
-  m_LocalScale: {x: 15, y: 1, z: 1}
+  m_LocalPosition: {x: -55.42, y: -3.5, z: 0}
+  m_LocalScale: {x: 20, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 333442906963005718}
@@ -4284,11 +4546,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -147.65001
+      value: -149.21
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4354,11 +4616,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -156.52388
+      value: -158.08388
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4494,11 +4756,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -136.02
+      value: -137.58
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.73
+      value: -0.652175
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4844,11 +5106,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -153.6
+      value: -155.16
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5124,11 +5386,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -150.57388
+      value: -152.13388
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5194,11 +5456,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -157.47
+      value: -159.03
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.78
+      value: -0.70217496
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5684,11 +5946,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -150.57388
+      value: -152.13388
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -6936,11 +7198,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -131.91388
+      value: -133.47388
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -7212,11 +7474,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -128.99
+      value: -130.55
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -7492,11 +7754,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -96.829994
+      value: -97.22999
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -7772,11 +8034,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -124.44001
+      value: -126.00001
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -7842,11 +8104,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -143.44
+      value: -145
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8052,11 +8314,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -95.45
+      value: -95.84999
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.5500002
+      value: 3.5600002
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8122,11 +8384,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 310302339358868674, guid: 66c5caee3cb17e8498414b232d1900b0, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -92.73819
+      value: -93.13818
       objectReference: {fileID: 0}
     - target: {fileID: 310302339358868674, guid: 66c5caee3cb17e8498414b232d1900b0, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.4693851
+      value: 3.4793851
       objectReference: {fileID: 0}
     - target: {fileID: 310302339358868674, guid: 66c5caee3cb17e8498414b232d1900b0, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8472,11 +8734,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -115.3
+      value: -115.7
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8682,11 +8944,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -98.23
+      value: -98.63
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.5500002
+      value: 3.5600002
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8962,11 +9224,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -156.52388
+      value: -158.08388
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -9534,11 +9796,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5245956931198689194, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -123.340004
+      value: -124.9
       objectReference: {fileID: 0}
     - target: {fileID: 5245956931198689194, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.77
+      value: -0.692175
       objectReference: {fileID: 0}
     - target: {fileID: 5245956931198689194, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
       propertyPath: m_LocalPosition.z
@@ -9942,11 +10204,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -153.6
+      value: -155.16
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -10082,11 +10344,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -137.54001
+      value: -139.1
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -10152,11 +10414,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -99.63
+      value: -100.02999
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -10292,11 +10554,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -109.31
+      value: -109.70999
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -10444,11 +10706,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5245956931198689194, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -112.843346
+      value: -113.24334
       objectReference: {fileID: 0}
     - target: {fileID: 5245956931198689194, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.6465578
+      value: 3.6565578
       objectReference: {fileID: 0}
     - target: {fileID: 5245956931198689194, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
       propertyPath: m_LocalPosition.z
@@ -10502,11 +10764,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -140.46388
+      value: -142.02388
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -11132,11 +11394,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -102.82
+      value: -103.21999
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -11762,11 +12024,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -90.58
+      value: -90.979996
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -11968,11 +12230,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -87.78
+      value: -88.17999
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -12664,11 +12926,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -112.5
+      value: -112.899994
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -13574,11 +13836,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -138.99
+      value: -140.55
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.73
+      value: -0.652175
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 3b9b1a800feeb874984994695464f392, type: 3}
       propertyPath: m_LocalPosition.z
@@ -14060,11 +14322,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -159.51001
+      value: -161.07
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.78
+      value: -0.70217496
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
       propertyPath: m_LocalPosition.z
@@ -14130,11 +14392,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -105.62
+      value: -106.02
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 5.01
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z
@@ -14410,11 +14672,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -147.65001
+      value: -149.21
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.722175
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4166910680685812857, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Prefabs/Resources/DiamondVein.prefab
+++ b/Assets/Prefabs/Resources/DiamondVein.prefab
@@ -179,12 +179,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 272052361, guid: c48e57cef2845e54d830d7d26fd721f8, type: 3}
+  m_Sprite: {fileID: 903583473, guid: c48e57cef2845e54d830d7d26fd721f8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.64, y: 0.64}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -227,7 +227,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 0.64, y: 0.64}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/Assets/Prefabs/Resources/GoldVein.prefab
+++ b/Assets/Prefabs/Resources/GoldVein.prefab
@@ -179,12 +179,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 524361238, guid: c48e57cef2845e54d830d7d26fd721f8, type: 3}
+  m_Sprite: {fileID: -1310241002, guid: c48e57cef2845e54d830d7d26fd721f8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.64, y: 0.64}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -227,7 +227,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 0.64, y: 0.64}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/Assets/Prefabs/Resources/IronVein.prefab
+++ b/Assets/Prefabs/Resources/IronVein.prefab
@@ -179,12 +179,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 864377751, guid: c48e57cef2845e54d830d7d26fd721f8, type: 3}
+  m_Sprite: {fileID: -554407730, guid: c48e57cef2845e54d830d7d26fd721f8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.64, y: 0.64}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -227,7 +227,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 0.64, y: 0.64}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/Assets/Scenes/LevelDesignScene.unity
+++ b/Assets/Scenes/LevelDesignScene.unity
@@ -1205,6 +1205,52 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &567763711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 567763713}
+  - component: {fileID: 567763712}
+  m_Layer: 0
+  m_Name: ResourceRespawnManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &567763712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567763711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4e19616a6a3fbf418789788bdd6c004, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  respawnDelayMin: 5
+  respawnDelayMax: 6
+--- !u!4 &567763713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567763711}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &583451894
 GameObject:
   m_ObjectHideFlags: 0
@@ -7451,6 +7497,10 @@ PrefabInstance:
       propertyPath: sceneId
       value: 2621189351
       objectReference: {fileID: 0}
+    - target: {fileID: 6784749683689810536, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.08
+      objectReference: {fileID: 0}
     - target: {fileID: 6812363411578598939, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
       propertyPath: sceneId
       value: 1995659148
@@ -7779,6 +7829,7 @@ SceneRoots:
   - {fileID: 469073550}
   - {fileID: 1206266857}
   - {fileID: 1143915375}
+  - {fileID: 567763713}
   - {fileID: 424713464}
   - {fileID: 1353921921}
   - {fileID: 1022963956}

--- a/Assets/Scenes/LevelDesignScene.unity
+++ b/Assets/Scenes/LevelDesignScene.unity
@@ -122,6 +122,216 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &50472019
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 5a4f7a94242282047ac5959bb29ca229, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_08
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+--- !u!1001 &95186729
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 26e96f1d78e0cc24e8509eb52dbc40b1, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Equipment_01
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &165629236
 GameObject:
   m_ObjectHideFlags: 0
@@ -324,6 +534,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &215997398 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 1249032236}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &221126371
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -417,6 +632,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+--- !u!224 &241972954 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 1065118811}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &301122663
 GameObject:
   m_ObjectHideFlags: 0
@@ -550,6 +770,16 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 301122663}
   m_CullTransparentMesh: 1
+--- !u!224 &326203012 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 95186729}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &412130359 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 917412012}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &424713463
 GameObject:
   m_ObjectHideFlags: 0
@@ -576,6 +806,140 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 29.65771, y: -11.465745, z: 0.12755537}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &469073546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 469073550}
+  - component: {fileID: 469073549}
+  - component: {fileID: 469073548}
+  - component: {fileID: 469073547}
+  m_Layer: 0
+  m_Name: ItemManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &469073547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 469073546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e264a0dbcb4f9849854e9f1731fedb3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resourceSets:
+  - resourceType: 0
+    resourcePrefab: {fileID: 5465408349737334575, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
+  - resourceType: 1
+    resourcePrefab: {fileID: 5465408349737334575, guid: 3b9b1a800feeb874984994695464f392, type: 3}
+  - resourceType: 2
+    resourcePrefab: {fileID: 5465408349737334575, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
+  - resourceType: 3
+    resourcePrefab: {fileID: 5465408349737334575, guid: 21b9337de44b78441af262631cb4b4bd, type: 3}
+  - resourceType: 4
+    resourcePrefab: {fileID: 5465408349737334575, guid: 197889a750c1e28449b475d382f4d82a, type: 3}
+  monsterSets:
+  - monsterType: 0
+    monsterPrefab: {fileID: 3547545519384445648, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
+  - monsterType: 1
+    monsterPrefab: {fileID: 3310435726288952766, guid: 66c5caee3cb17e8498414b232d1900b0, type: 3}
+  - monsterType: 2
+    monsterPrefab: {fileID: 1106276074698760010, guid: dbcddb2477526ad4887e339a78df6bfe, type: 3}
+--- !u!114 &469073548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 469073546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e5491aae7402b3429d811fe5ec566a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemPrefab: {fileID: -2550920458885841942, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+--- !u!114 &469073549
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 469073546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7421a0f6c8ada0a469e8895fd493c8c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemPrefabs:
+  - itemCode: Ingredient_00
+    itemPrefab: {fileID: 7363160457919382477, guid: 9763d4cf8c10648459659ff44b9e2b46, type: 3}
+  - itemCode: Ingredient_01
+    itemPrefab: {fileID: 7363160457919382477, guid: 4bb35e1744c4a354189dbf21d60fbcc3, type: 3}
+  - itemCode: Ingredient_02
+    itemPrefab: {fileID: 7363160457919382477, guid: 607de423664e5954bb25f3dd909dd85d, type: 3}
+  - itemCode: Ingredient_03
+    itemPrefab: {fileID: 7363160457919382477, guid: 440601d7347f2c84cb66de850fa60ab1, type: 3}
+  - itemCode: Ingredient_04
+    itemPrefab: {fileID: 7363160457919382477, guid: 0612c45f67fb9bb4e8b58d0ead2db3ec, type: 3}
+  - itemCode: Ingredient_05
+    itemPrefab: {fileID: 7363160457919382477, guid: 5fce46d4eaa67c343a21911a3ee6067e, type: 3}
+  - itemCode: Ingredient_06
+    itemPrefab: {fileID: 7363160457919382477, guid: 4dcd996c1df4d1049b7138c3b5d37057, type: 3}
+  - itemCode: Ingredient_07
+    itemPrefab: {fileID: 7363160457919382477, guid: c4db0865b6861774d9abfded8fd414ab, type: 3}
+  - itemCode: Ingredient_08
+    itemPrefab: {fileID: 7363160457919382477, guid: 09eac3d9c41734849aff7089931a7f80, type: 3}
+  - itemCode: Ingredient_09
+    itemPrefab: {fileID: 7363160457919382477, guid: 61348b17afe03b249afbe772a3a569e1, type: 3}
+  - itemCode: Ingredient_10
+    itemPrefab: {fileID: 7363160457919382477, guid: b9758aaf77e07e9479bd5ee34fb58529, type: 3}
+  - itemCode: Ingredient_11
+    itemPrefab: {fileID: 7363160457919382477, guid: 3b005ca5ebb35884588d386579a081a0, type: 3}
+  - itemCode: Equipment_01
+    itemPrefab: {fileID: 7507301870768487481, guid: 58aeb69b8c7c542428b2cb1d4e24fe02, type: 3}
+  - itemCode: Equipment_02
+    itemPrefab: {fileID: 8448248930150657756, guid: 0f0eeb5b7fa08114dbc83493d69fdc1f, type: 3}
+  - itemCode: Equipment_03
+    itemPrefab: {fileID: 5835402318371152493, guid: 4ea64f2adba311949a6054efe61b4a6a, type: 3}
+  - itemCode: Equipment_04
+    itemPrefab: {fileID: 9050712519032557110, guid: a1807153aed725943944a66d827ed56c, type: 3}
+  - itemCode: Equipment_05
+    itemPrefab: {fileID: 8477398196338840477, guid: 06d215d0fd716f643a365b848cd52fb6, type: 3}
+  - itemCode: Equipment_06
+    itemPrefab: {fileID: 4927897567675928663, guid: fbd8eec22f0411a4ba7e95727c45ba93, type: 3}
+  - itemCode: Equipment_07
+    itemPrefab: {fileID: 7507301870768487481, guid: 7849c9147650e86429e2c4e3c19b5ad9, type: 3}
+  - itemCode: Equipment_08
+    itemPrefab: {fileID: 8448248930150657756, guid: 5e0bfa004dc1eff42b92e3de42b5e1ff, type: 3}
+  - itemCode: Food_01
+    itemPrefab: {fileID: 7363160457919382477, guid: 8b87dede44f789042854f60bad0575a9, type: 3}
+  - itemCode: Food_02
+    itemPrefab: {fileID: 7363160457919382477, guid: e9d547d3553c5924ab0be0e890a48511, type: 3}
+--- !u!4 &469073550
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 469073546}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.9514139, y: 2.7793431, z: -0.07231887}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -841,6 +1205,52 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &567763711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 567763713}
+  - component: {fileID: 567763712}
+  m_Layer: 0
+  m_Name: ResourceRespawnManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &567763712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567763711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4e19616a6a3fbf418789788bdd6c004, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  respawnDelayMin: 5
+  respawnDelayMax: 6
+--- !u!4 &567763713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567763711}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &583451894
 GameObject:
   m_ObjectHideFlags: 0
@@ -872,6 +1282,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &628419045 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 1031145209}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &641789724
 GameObject:
   m_ObjectHideFlags: 0
@@ -1314,6 +1729,121 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 703542871}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &735515313 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 1901688435}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &746599364 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 50472019}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &775226284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: cc21aef0d9ff54a458de48afc2b68d86, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_09
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &791692156
 GameObject:
   m_ObjectHideFlags: 0
@@ -1524,6 +2054,111 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 796631494}
   m_CullTransparentMesh: 1
+--- !u!1001 &842065194
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c08a988d2926ad24cacd6bbc6909f91b, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Equipment_03
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1001 &849757341
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1921,6 +2556,111 @@ MonoBehaviour:
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
+--- !u!1001 &917412012
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: fbdfc51caaee533439e2375d7ae27c89, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_06
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &939124868
 GameObject:
   m_ObjectHideFlags: 0
@@ -2281,6 +3021,116 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 952363603}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &953520282
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: abc4ff160587b3945a8b25c75f824f41, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_11
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+--- !u!224 &953520283 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 953520282}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &982151059
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2610,6 +3460,115 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+--- !u!1001 &1031145209
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ef006e3f285f860489dea1aa7f3e4943, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8494580317447626088, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1001 &1032368911
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2885,6 +3844,111 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &1065118811
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3b1b4e447f5b44e4da16ce1c0b9ac802, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Equipment_02
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &1065333763
 GameObject:
   m_ObjectHideFlags: 0
@@ -3318,6 +4382,73 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+--- !u!224 &1108305619 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 775226284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1128882901 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 842065194}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1143915373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1143915375}
+  - component: {fileID: 1143915374}
+  m_Layer: 0
+  m_Name: CraftingManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1143915374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1143915373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9f4a40d219d628d4d9fc811061c436a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  recipes:
+  - {fileID: 11400000, guid: f676e12e752b97d43a758f210fe88ee1, type: 2}
+  - {fileID: 11400000, guid: 473ebc1c5dbf3a644ab345d4403b1e52, type: 2}
+  - {fileID: 11400000, guid: 35b0569a4a402c94e82b1073bc719fa2, type: 2}
+  - {fileID: 11400000, guid: e6aec1e99f5ec2847b5d8e35c55c3a2f, type: 2}
+  - {fileID: 11400000, guid: 66b04d5f74a5bae4588353d227834ced, type: 2}
+  - {fileID: 11400000, guid: c410472ad4b36b548ab4dbf4dc348446, type: 2}
+  - {fileID: 11400000, guid: adc9618f634855444bb1f3de7c177fde, type: 2}
+  - {fileID: 11400000, guid: 09b05413bc7e00949ba6a03bce49d56c, type: 2}
+  - {fileID: 11400000, guid: 448e83ba9c9acee4386da1a5104d7a5a, type: 2}
+  - {fileID: 11400000, guid: 055d46d8a7713ef4ca5ff035438002a6, type: 2}
+  - {fileID: 11400000, guid: 5df355d03a9f93b44b1a50a7a456283d, type: 2}
+  - {fileID: 11400000, guid: f9ba88b5be1b35c4ebb6f427c27932ac, type: 2}
+--- !u!4 &1143915375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1143915373}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.1062005, y: -12.601926, z: -0.32053232}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1169977013
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3841,6 +4972,111 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1249032236
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 6481a9920178dc4478149a709e723909, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_10
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &1328613641
 GameObject:
   m_ObjectHideFlags: 0
@@ -4344,16 +5580,118 @@ RectTransform:
   m_AnchoredPosition: {x: 342, y: 46}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1490532061 stripped
+--- !u!1 &1490532061
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 3646624337890965642, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
-  m_PrefabInstance: {fileID: 3104570587457560370}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &1490532062 stripped
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1490532062}
+  - component: {fileID: 1490532064}
+  - component: {fileID: 1490532063}
+  - component: {fileID: 1490532065}
+  m_Layer: 5
+  m_Name: CraftUIBG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1490532062
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
-  m_PrefabInstance: {fileID: 3104570587457560370}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490532061}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5918993213446219431}
+  - {fileID: 412130359}
+  - {fileID: 746599364}
+  - {fileID: 326203012}
+  - {fileID: 241972954}
+  - {fileID: 1128882901}
+  - {fileID: 1108305619}
+  - {fileID: 735515313}
+  - {fileID: 628419045}
+  - {fileID: 1548011065}
+  - {fileID: 215997398}
+  - {fileID: 953520283}
+  m_Father: {fileID: 1064134586}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 484, y: 0}
+  m_SizeDelta: {x: 410, y: 550}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1490532063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490532061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1490532064
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490532061}
+  m_CullTransparentMesh: 1
+--- !u!114 &1490532065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490532061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 10
+    m_Bottom: 10
+  m_ChildAlignment: 0
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 120, y: 120}
+  m_Spacing: {x: 15, y: 15}
+  m_Constraint: 0
+  m_ConstraintCount: 2
 --- !u!1 &1539844098
 GameObject:
   m_ObjectHideFlags: 0
@@ -4488,6 +5826,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1539844098}
   m_CullTransparentMesh: 1
+--- !u!224 &1548011065 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 2102143674}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1572528046
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5342,6 +6685,111 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 1868609920}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1901688435
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1490532062}
+    m_Modifications:
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Name
+      value: CraftSlot (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d3520eb9a5bd24a4f9d9b88914521a31, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Equipment_04
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &1938140039
 GameObject:
   m_ObjectHideFlags: 0
@@ -5476,63 +6924,111 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1938140039}
   m_CullTransparentMesh: 1
---- !u!1001 &918951370788625628
+--- !u!1001 &2102143674
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1490532062}
     m_Modifications:
-    - target: {fileID: 344581304677706969, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_Name
-      value: CraftingManager
+      value: CraftSlot (9)
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.1062005
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -12.601926
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.32053232
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b3fa422a1a7d54f47acfc17d06e4ad78, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Equipment_06
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1001 &937999927552142405
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6001,6 +7497,10 @@ PrefabInstance:
       propertyPath: sceneId
       value: 2621189351
       objectReference: {fileID: 0}
+    - target: {fileID: 6784749683689810536, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.08
+      objectReference: {fileID: 0}
     - target: {fileID: 6812363411578598939, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
       propertyPath: sceneId
       value: 1995659148
@@ -6109,34 +7609,6 @@ PrefabInstance:
       propertyPath: sceneId
       value: 2064567156
       objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.data[2].itemID
-      value: Ingredient_12
-      objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.data[3].itemID
-      value: Food_02
-      objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.data[4].itemID
-      value: Food_01
-      objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.data[2].itemCount
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.data[3].itemCount
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 7740187219194739869, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
-      propertyPath: dropItemSets.Array.data[4].itemCount
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 7785248789910428413, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
       propertyPath: sceneId
       value: 4041113493
@@ -6230,160 +7702,116 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
---- !u!1001 &3104570587457560370
+--- !u!1001 &5918993213446219430
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1064134586}
+    m_TransformParent: {fileID: 1490532062}
     m_Modifications:
-    - target: {fileID: 3646624337890965642, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_Name
-      value: CraftUIBG
+      value: CraftSlot
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 410
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 550
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 484
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c397956f0106fce40b6a0c5c672f2939, type: 3}
+    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+      propertyPath: itemID
+      value: Ingredient_07
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
---- !u!1001 &7373893903392384282
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.9514139
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.7793431
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.07231887
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5169305199875252912, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
-      propertyPath: m_Name
-      value: ItemManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+--- !u!224 &5918993213446219431 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_PrefabInstance: {fileID: 5918993213446219430}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -6398,9 +7826,10 @@ SceneRoots:
   - {fileID: 183790309}
   - {fileID: 939124873}
   - {fileID: 1658348809}
-  - {fileID: 7373893903392384282}
+  - {fileID: 469073550}
   - {fileID: 1206266857}
-  - {fileID: 918951370788625628}
+  - {fileID: 1143915375}
+  - {fileID: 567763713}
   - {fileID: 424713464}
   - {fileID: 1353921921}
   - {fileID: 1022963956}

--- a/Assets/Scenes/LevelDesignScene.unity
+++ b/Assets/Scenes/LevelDesignScene.unity
@@ -122,216 +122,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &50472019
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 5a4f7a94242282047ac5959bb29ca229, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_08
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
---- !u!1001 &95186729
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 26e96f1d78e0cc24e8509eb52dbc40b1, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Equipment_01
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &165629236
 GameObject:
   m_ObjectHideFlags: 0
@@ -534,11 +324,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!224 &215997398 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 1249032236}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &221126371
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -632,11 +417,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
---- !u!224 &241972954 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 1065118811}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &301122663
 GameObject:
   m_ObjectHideFlags: 0
@@ -770,16 +550,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 301122663}
   m_CullTransparentMesh: 1
---- !u!224 &326203012 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 95186729}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &412130359 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 917412012}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &424713463
 GameObject:
   m_ObjectHideFlags: 0
@@ -806,140 +576,6 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 29.65771, y: -11.465745, z: 0.12755537}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &469073546
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 469073550}
-  - component: {fileID: 469073549}
-  - component: {fileID: 469073548}
-  - component: {fileID: 469073547}
-  m_Layer: 0
-  m_Name: ItemManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &469073547
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469073546}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9e264a0dbcb4f9849854e9f1731fedb3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  resourceSets:
-  - resourceType: 0
-    resourcePrefab: {fileID: 5465408349737334575, guid: f1a7aab8f47064a44920c11eacaaa038, type: 3}
-  - resourceType: 1
-    resourcePrefab: {fileID: 5465408349737334575, guid: 3b9b1a800feeb874984994695464f392, type: 3}
-  - resourceType: 2
-    resourcePrefab: {fileID: 5465408349737334575, guid: 4e2e4a8d7957c814aa5394743ab6e1bf, type: 3}
-  - resourceType: 3
-    resourcePrefab: {fileID: 5465408349737334575, guid: 21b9337de44b78441af262631cb4b4bd, type: 3}
-  - resourceType: 4
-    resourcePrefab: {fileID: 5465408349737334575, guid: 197889a750c1e28449b475d382f4d82a, type: 3}
-  monsterSets:
-  - monsterType: 0
-    monsterPrefab: {fileID: 3547545519384445648, guid: fca5eac9ea198a94c894b485c716ef7b, type: 3}
-  - monsterType: 1
-    monsterPrefab: {fileID: 3310435726288952766, guid: 66c5caee3cb17e8498414b232d1900b0, type: 3}
-  - monsterType: 2
-    monsterPrefab: {fileID: 1106276074698760010, guid: dbcddb2477526ad4887e339a78df6bfe, type: 3}
---- !u!114 &469073548
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469073546}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5e5491aae7402b3429d811fe5ec566a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  itemPrefab: {fileID: -2550920458885841942, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
---- !u!114 &469073549
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469073546}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7421a0f6c8ada0a469e8895fd493c8c5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  itemPrefabs:
-  - itemCode: Ingredient_00
-    itemPrefab: {fileID: 7363160457919382477, guid: 9763d4cf8c10648459659ff44b9e2b46, type: 3}
-  - itemCode: Ingredient_01
-    itemPrefab: {fileID: 7363160457919382477, guid: 4bb35e1744c4a354189dbf21d60fbcc3, type: 3}
-  - itemCode: Ingredient_02
-    itemPrefab: {fileID: 7363160457919382477, guid: 607de423664e5954bb25f3dd909dd85d, type: 3}
-  - itemCode: Ingredient_03
-    itemPrefab: {fileID: 7363160457919382477, guid: 440601d7347f2c84cb66de850fa60ab1, type: 3}
-  - itemCode: Ingredient_04
-    itemPrefab: {fileID: 7363160457919382477, guid: 0612c45f67fb9bb4e8b58d0ead2db3ec, type: 3}
-  - itemCode: Ingredient_05
-    itemPrefab: {fileID: 7363160457919382477, guid: 5fce46d4eaa67c343a21911a3ee6067e, type: 3}
-  - itemCode: Ingredient_06
-    itemPrefab: {fileID: 7363160457919382477, guid: 4dcd996c1df4d1049b7138c3b5d37057, type: 3}
-  - itemCode: Ingredient_07
-    itemPrefab: {fileID: 7363160457919382477, guid: c4db0865b6861774d9abfded8fd414ab, type: 3}
-  - itemCode: Ingredient_08
-    itemPrefab: {fileID: 7363160457919382477, guid: 09eac3d9c41734849aff7089931a7f80, type: 3}
-  - itemCode: Ingredient_09
-    itemPrefab: {fileID: 7363160457919382477, guid: 61348b17afe03b249afbe772a3a569e1, type: 3}
-  - itemCode: Ingredient_10
-    itemPrefab: {fileID: 7363160457919382477, guid: b9758aaf77e07e9479bd5ee34fb58529, type: 3}
-  - itemCode: Ingredient_11
-    itemPrefab: {fileID: 7363160457919382477, guid: 3b005ca5ebb35884588d386579a081a0, type: 3}
-  - itemCode: Equipment_01
-    itemPrefab: {fileID: 7507301870768487481, guid: 58aeb69b8c7c542428b2cb1d4e24fe02, type: 3}
-  - itemCode: Equipment_02
-    itemPrefab: {fileID: 8448248930150657756, guid: 0f0eeb5b7fa08114dbc83493d69fdc1f, type: 3}
-  - itemCode: Equipment_03
-    itemPrefab: {fileID: 5835402318371152493, guid: 4ea64f2adba311949a6054efe61b4a6a, type: 3}
-  - itemCode: Equipment_04
-    itemPrefab: {fileID: 9050712519032557110, guid: a1807153aed725943944a66d827ed56c, type: 3}
-  - itemCode: Equipment_05
-    itemPrefab: {fileID: 8477398196338840477, guid: 06d215d0fd716f643a365b848cd52fb6, type: 3}
-  - itemCode: Equipment_06
-    itemPrefab: {fileID: 4927897567675928663, guid: fbd8eec22f0411a4ba7e95727c45ba93, type: 3}
-  - itemCode: Equipment_07
-    itemPrefab: {fileID: 7507301870768487481, guid: 7849c9147650e86429e2c4e3c19b5ad9, type: 3}
-  - itemCode: Equipment_08
-    itemPrefab: {fileID: 8448248930150657756, guid: 5e0bfa004dc1eff42b92e3de42b5e1ff, type: 3}
-  - itemCode: Food_01
-    itemPrefab: {fileID: 7363160457919382477, guid: 8b87dede44f789042854f60bad0575a9, type: 3}
-  - itemCode: Food_02
-    itemPrefab: {fileID: 7363160457919382477, guid: e9d547d3553c5924ab0be0e890a48511, type: 3}
---- !u!4 &469073550
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469073546}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.9514139, y: 2.7793431, z: -0.07231887}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1236,6 +872,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnDelayMin: 5
   respawnDelayMax: 6
+  monsterRespawnMin: 10
+  monsterRespawnMax: 15
 --- !u!4 &567763713
 Transform:
   m_ObjectHideFlags: 0
@@ -1251,6 +889,99 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &579034117
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -2550920458885841942, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: itemID
+      value: Equipment_06
+      objectReference: {fileID: 0}
+    - target: {fileID: 2138057457643425766, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b3fa422a1a7d54f47acfc17d06e4ad78, type: 3}
+    - target: {fileID: 2518856736968486608, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: sceneId
+      value: 4190375623
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3094612050912296098, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3483125285752344954, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3483125285752344954, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3483125285752344954, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3483125285752344954, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3483125285752344954, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.x
+      value: 0.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3483125285752344954, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.y
+      value: 0.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328445041376920398, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
+      propertyPath: m_Name
+      value: TestIronSword
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
 --- !u!1 &583451894
 GameObject:
   m_ObjectHideFlags: 0
@@ -1282,11 +1013,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!224 &628419045 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 1031145209}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &641789724
 GameObject:
   m_ObjectHideFlags: 0
@@ -1729,121 +1455,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 703542871}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &735515313 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 1901688435}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &746599364 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 50472019}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &775226284
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: cc21aef0d9ff54a458de48afc2b68d86, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_09
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &791692156
 GameObject:
   m_ObjectHideFlags: 0
@@ -2054,111 +1665,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 796631494}
   m_CullTransparentMesh: 1
---- !u!1001 &842065194
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: c08a988d2926ad24cacd6bbc6909f91b, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Equipment_03
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1001 &849757341
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2556,111 +2062,6 @@ MonoBehaviour:
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
---- !u!1001 &917412012
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: fbdfc51caaee533439e2375d7ae27c89, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_06
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &939124868
 GameObject:
   m_ObjectHideFlags: 0
@@ -3021,116 +2422,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 952363603}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &953520282
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (11)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: abc4ff160587b3945a8b25c75f824f41, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_11
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
---- !u!224 &953520283 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 953520282}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &982151059
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3460,115 +2751,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
---- !u!1001 &1031145209
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (8)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: ef006e3f285f860489dea1aa7f3e4943, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_11
-      objectReference: {fileID: 0}
-    - target: {fileID: 8494580317447626088, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1001 &1032368911
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3836,7 +3018,7 @@ RectTransform:
   m_Children:
   - {fileID: 641789725}
   - {fileID: 1644092268}
-  - {fileID: 1490532062}
+  - {fileID: 1591041830}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3844,111 +3026,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1001 &1065118811
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 3b1b4e447f5b44e4da16ce1c0b9ac802, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Equipment_02
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &1065333763
 GameObject:
   m_ObjectHideFlags: 0
@@ -4382,73 +3459,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a64739c261b43b94b91f5404049e9d90, type: 3}
---- !u!224 &1108305619 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 775226284}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &1128882901 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 842065194}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1143915373
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1143915375}
-  - component: {fileID: 1143915374}
-  m_Layer: 0
-  m_Name: CraftingManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1143915374
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1143915373}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9f4a40d219d628d4d9fc811061c436a4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  recipes:
-  - {fileID: 11400000, guid: f676e12e752b97d43a758f210fe88ee1, type: 2}
-  - {fileID: 11400000, guid: 473ebc1c5dbf3a644ab345d4403b1e52, type: 2}
-  - {fileID: 11400000, guid: 35b0569a4a402c94e82b1073bc719fa2, type: 2}
-  - {fileID: 11400000, guid: e6aec1e99f5ec2847b5d8e35c55c3a2f, type: 2}
-  - {fileID: 11400000, guid: 66b04d5f74a5bae4588353d227834ced, type: 2}
-  - {fileID: 11400000, guid: c410472ad4b36b548ab4dbf4dc348446, type: 2}
-  - {fileID: 11400000, guid: adc9618f634855444bb1f3de7c177fde, type: 2}
-  - {fileID: 11400000, guid: 09b05413bc7e00949ba6a03bce49d56c, type: 2}
-  - {fileID: 11400000, guid: 448e83ba9c9acee4386da1a5104d7a5a, type: 2}
-  - {fileID: 11400000, guid: 055d46d8a7713ef4ca5ff035438002a6, type: 2}
-  - {fileID: 11400000, guid: 5df355d03a9f93b44b1a50a7a456283d, type: 2}
-  - {fileID: 11400000, guid: f9ba88b5be1b35c4ebb6f427c27932ac, type: 2}
---- !u!4 &1143915375
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1143915373}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.1062005, y: -12.601926, z: -0.32053232}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1169977013
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4916,6 +3926,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1174219931}
   m_CullTransparentMesh: 1
+--- !u!1001 &1200949977
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.9514139
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.7793431
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.07231887
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456199257621523099, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5169305199875252912, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
+      propertyPath: m_Name
+      value: ItemManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b108e229e8c6c5c4bbeaf02a8ce7b1a1, type: 3}
 --- !u!1 &1206266855
 GameObject:
   m_ObjectHideFlags: 0
@@ -4954,7 +4021,7 @@ MonoBehaviour:
   selectedItemStatValue: {fileID: 1656200578}
   useButton: {fileID: 301122665}
   dropButton: {fileID: 791692158}
-  craftingPanel: {fileID: 1490532061}
+  craftingPanel: {fileID: 0}
   craftButton: {fileID: 513258463}
   craftWarningText: {fileID: 1475104410}
 --- !u!4 &1206266857
@@ -4972,111 +4039,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1249032236
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (10)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 6481a9920178dc4478149a709e723909, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_10
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &1328613641
 GameObject:
   m_ObjectHideFlags: 0
@@ -5580,118 +4542,6 @@ RectTransform:
   m_AnchoredPosition: {x: 342, y: 46}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1490532061
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1490532062}
-  - component: {fileID: 1490532064}
-  - component: {fileID: 1490532063}
-  - component: {fileID: 1490532065}
-  m_Layer: 5
-  m_Name: CraftUIBG
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1490532062
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1490532061}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5918993213446219431}
-  - {fileID: 412130359}
-  - {fileID: 746599364}
-  - {fileID: 326203012}
-  - {fileID: 241972954}
-  - {fileID: 1128882901}
-  - {fileID: 1108305619}
-  - {fileID: 735515313}
-  - {fileID: 628419045}
-  - {fileID: 1548011065}
-  - {fileID: 215997398}
-  - {fileID: 953520283}
-  m_Father: {fileID: 1064134586}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 484, y: 0}
-  m_SizeDelta: {x: 410, y: 550}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1490532063
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1490532061}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1490532064
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1490532061}
-  m_CullTransparentMesh: 1
---- !u!114 &1490532065
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1490532061}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 10
-    m_Right: 10
-    m_Top: 10
-    m_Bottom: 10
-  m_ChildAlignment: 0
-  m_StartCorner: 0
-  m_StartAxis: 0
-  m_CellSize: {x: 120, y: 120}
-  m_Spacing: {x: 15, y: 15}
-  m_Constraint: 0
-  m_ConstraintCount: 2
 --- !u!1 &1539844098
 GameObject:
   m_ObjectHideFlags: 0
@@ -5826,11 +4676,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1539844098}
   m_CullTransparentMesh: 1
---- !u!224 &1548011065 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 2102143674}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1572528046
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5932,6 +4777,468 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 1572528046}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1591041829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1064134586}
+    m_Modifications:
+    - target: {fileID: 393683667837763464, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 393683667837763464, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 393683667837763464, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 393683667837763464, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 393683667837763464, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 393683667837763464, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592557893755312156, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592557893755312156, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592557893755312156, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592557893755312156, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592557893755312156, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 592557893755312156, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1351344606099385871, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1351344606099385871, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1351344606099385871, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1351344606099385871, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1351344606099385871, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1351344606099385871, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650904892001339747, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650904892001339747, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650904892001339747, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650904892001339747, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650904892001339747, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650904892001339747, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965647509411589584, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965647509411589584, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965647509411589584, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965647509411589584, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965647509411589584, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965647509411589584, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3646624337890965642, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_Name
+      value: CraftUIBG
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437964762451215989, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437964762451215989, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437964762451215989, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437964762451215989, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437964762451215989, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437964762451215989, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 410
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 550
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 484
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949368581754425786, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949368581754425786, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949368581754425786, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949368581754425786, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949368581754425786, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949368581754425786, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6067978736191148465, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6067978736191148465, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6067978736191148465, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6067978736191148465, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6067978736191148465, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6067978736191148465, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6255569474130810415, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6255569474130810415, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6255569474130810415, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6255569474130810415, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6255569474130810415, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6255569474130810415, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6405538025597197811, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6405538025597197811, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6405538025597197811, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6405538025597197811, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6405538025597197811, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6405538025597197811, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7491544269642896520, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7491544269642896520, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7491544269642896520, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7491544269642896520, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7491544269642896520, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7491544269642896520, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520662567745206370, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520662567745206370, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520662567745206370, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520662567745206370, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520662567745206370, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520662567745206370, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8523516769719107733, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8523516769719107733, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8523516769719107733, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8523516769719107733, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8523516769719107733, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8523516769719107733, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565558959770739849, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565558959770739849, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565558959770739849, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565558959770739849, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565558959770739849, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565558959770739849, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887704474809332818, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887704474809332818, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887704474809332818, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887704474809332818, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887704474809332818, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887704474809332818, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+--- !u!224 &1591041830 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5147446722829418837, guid: d9c97837c1a3d9145b98b9ca94e1de78, type: 3}
+  m_PrefabInstance: {fileID: 1591041829}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1644092267
 GameObject:
@@ -6685,111 +5992,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 652459729977316115, guid: 7871b14167e703d45a1899281ed7ed47, type: 3}
   m_PrefabInstance: {fileID: 1868609920}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1901688435
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d3520eb9a5bd24a4f9d9b88914521a31, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Equipment_04
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
 --- !u!1 &1938140039
 GameObject:
   m_ObjectHideFlags: 0
@@ -6924,111 +6126,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1938140039}
   m_CullTransparentMesh: 1
---- !u!1001 &2102143674
+--- !u!1001 &1995076980
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 344581304677706969, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_Name
-      value: CraftSlot (9)
+      value: CraftingManager
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 3.1062005
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -12.601926
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.32053232
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+    - target: {fileID: 9218627588013705199, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: b3fa422a1a7d54f47acfc17d06e4ad78, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Equipment_06
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 381785a1d16d4df4fa3cafd4edb5f4d5, type: 3}
 --- !u!1001 &937999927552142405
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7702,116 +6856,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 30e6dbca12164054e84bc380a690d10d, type: 3}
---- !u!1001 &5918993213446219430
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1490532062}
-    m_Modifications:
-    - target: {fileID: 2445771989864324540, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Name
-      value: CraftSlot
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6205777195335564478, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: c397956f0106fce40b6a0c5c672f2939, type: 3}
-    - target: {fileID: 8432955230162750685, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-      propertyPath: itemID
-      value: Ingredient_07
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
---- !u!224 &5918993213446219431 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5783904646761615321, guid: e8320ff68ccb1c2459f66c53270e9644, type: 3}
-  m_PrefabInstance: {fileID: 5918993213446219430}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -7826,10 +6870,10 @@ SceneRoots:
   - {fileID: 183790309}
   - {fileID: 939124873}
   - {fileID: 1658348809}
-  - {fileID: 469073550}
   - {fileID: 1206266857}
-  - {fileID: 1143915375}
   - {fileID: 567763713}
+  - {fileID: 1995076980}
+  - {fileID: 1200949977}
   - {fileID: 424713464}
   - {fileID: 1353921921}
   - {fileID: 1022963956}
@@ -7839,3 +6883,4 @@ SceneRoots:
   - {fileID: 688489597}
   - {fileID: 221126371}
   - {fileID: 1172753886}
+  - {fileID: 579034117}

--- a/Assets/Scripts/HyoHun/Equipment/HandyToolItem.cs
+++ b/Assets/Scripts/HyoHun/Equipment/HandyToolItem.cs
@@ -55,6 +55,7 @@ public abstract class HandyToolItem : Item
         isUsing = true;
 
         // 콜라이더 세팅
+        attackPoint.SetActive(true);
         attackCollider.enabled = true;
         attackCollider.transform.localScale = Vector3.one * size;
 
@@ -64,6 +65,8 @@ public abstract class HandyToolItem : Item
 
         // 혹시 몰라서 태그 초기화
         attackPoint.tag = "Untagged";
+
+        attackPoint.SetActive(false);
 
         isUsing = false;
     }

--- a/Assets/Scripts/HyoHun/Food/SteakItem.cs
+++ b/Assets/Scripts/HyoHun/Food/SteakItem.cs
@@ -12,6 +12,7 @@ public class SteakItem : FoodItem
     public override void Use(PlayerController user)
     {
         Debug.Log($"{itemName}을 먹고 체력을 {healAmount}만큼 회복했다.");
+        base.Use(user);
         //회복 처리 
         //이 아이템 소비 처리
         //PlayerHealth.Instance.Heal(healAmount);

--- a/Assets/Scripts/Local/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Local/Inventory/InventoryManager.cs
@@ -103,17 +103,7 @@ public class InventoryManager : Singleton<InventoryManager>
         }
 
         // 슬롯 없음 >> 바닥에 드롭
-        ThrowItem(newItem);
-    }
-
-    /// <summary>
-    /// 아이템 버리기
-    /// </summary>
-    public void ThrowItem(Item item)
-    {
-        //플레이어 위치에 드롭
-        //위치는 NetworkManager에서 client를 찾아 설정
-        NetworkItemManager.Instance.SpawnItem(item.itemID, NetworkClient.localPlayer.transform.position, false);
+        NetworkClient.localPlayer.GetComponent<PlayerController>().ThrowItem(newItem.itemID);
     }
 
     /// <summary>
@@ -219,7 +209,7 @@ public class InventoryManager : Singleton<InventoryManager>
     /// </summary>
     public void OnDropButton()
     {
-        ThrowItem(selectedItem.inventoryItem); // TODO: 실제 드롭 구현 시 selectedItem 사용
+        NetworkClient.localPlayer.GetComponent<PlayerController>().ThrowItem(selectedItem.inventoryItem.itemID);
         RemoveSelectedItem();
     }
 

--- a/Assets/Scripts/Local/MonsterController.cs
+++ b/Assets/Scripts/Local/MonsterController.cs
@@ -179,6 +179,12 @@ public class MonsterController : NetworkBehaviour
     private float currentActionTime = 0f; // 현재 행동 시간
     private float maxActionTime = 0f; // 최대 행동 시간
 
+    [ClientRpc]
+    private void RpcSetActive(bool isActive)
+    {
+        gameObject.SetActive(isActive);
+    }
+
     /// <summary>
     /// 로컬 데이터 초기화 할때 사용
     /// </summary>
@@ -273,9 +279,47 @@ public class MonsterController : NetworkBehaviour
             // 아이템 드롭
             DropItem();
 
+            // 서버에서만 처리
+            if (isServer)
+            {
+                // 오브젝트 비활성화 (서버에서 실행되면 클라에도 반영됨)
+                RpcSetActive(false);
+
+                // 리스폰 요청
+                ResourceRespawnManager.Instance.RequestMonsterRespawn(gameObject);
+            }
+
             // 생명체 오브젝트 파괴
-            NetworkResourceManager.Instance.DestroyMonster(gameObject);
+            //NetworkResourceManager.Instance.DestroyMonster(gameObject);
         }
+    }
+
+    [Server]
+    public void ResetMonster()
+    {
+        currentHealth = fullHealth;
+
+        healthBar.fillAmount = 1; // 체력바 초기화
+        if (healthBar != null)
+        {
+            healthBarBG.SetActive(false); // 시작 시 체력바 비활성화
+        }
+        /*
+        if (isServer)
+        {
+            DecideNextAction(); // 서버에서 몬스터 행동 결정
+        }
+        */
+        // 필요하다면 위치도 초기화
+        // transform.position = spawnPoint;
+
+        if (animator != null)
+        {
+            animator.Rebind();  // 애니메이션 초기화
+            animator.Update(0f);
+        }
+
+        RpcSetActive(true); // 클라이언트들도 활성화
     }
 
     /// <summary>

--- a/Assets/Scripts/Local/PlayerController.cs
+++ b/Assets/Scripts/Local/PlayerController.cs
@@ -38,13 +38,13 @@ public class PlayerController : NetworkBehaviour
     private float m_delayToIdle = 0.0f;
     private float m_rollDuration = 8.0f / 14.0f;
     private float m_rollCurrentTime;
-    private int overlappingLadderCount = 0; // í”Œë ˆì´ì–´ê°€ ì‚¬ë‹¤ë¦¬ì™€ ê²¹ì¹œíšŸìˆ˜ 0ë³´ë‹¤ í¬ë©´ ì‚¬ë‹¤ë¦¬ ìœ„ì— ìˆìŒ
+    private int overlappingLadderCount = 0; // ÇÃ·¹ÀÌ¾î°¡ »ç´Ù¸®¿Í °ãÄ£È½¼ö 0º¸´Ù Å©¸é »ç´Ù¸® À§¿¡ ÀÖÀ½
     private float vertical;
 
-    [Header("ë„êµ¬ ì‚¬ìš©")]
-    public GameObject attackPoint;  //ê³µê²© ë²”ìœ„ íŒì •ìš© ì˜¤ë¸Œì íŠ¸ 
-    //ì¸ë²¤í† ë¦¬ ì ‘ê·¼ìš© InventoryManager
-    //private bool isEquipped = false; //ì†ì— ì¥ë¹„ ì¥ì°© ì—¬ë¶€
+    [Header("µµ±¸ »ç¿ë")]
+    public GameObject attackPoint;  //°ø°İ ¹üÀ§ ÆÇÁ¤¿ë ¿ÀºêÁ§Æ® 
+    //ÀÎº¥Åä¸® Á¢±Ù¿ë InventoryManager
+    //private bool isEquipped = false; //¼Õ¿¡ Àåºñ ÀåÂø ¿©ºÎ
 
 
     // Use this for initialization
@@ -52,12 +52,12 @@ public class PlayerController : NetworkBehaviour
     {
         if (isLocalPlayer && SteamManager.Initialized)
         {
-            // ë‚´ ì´ë¦„ì„ ê°€ì ¸ì™€ì„œ ì„œë²„ì— ì„¤ì •
+            // ³» ÀÌ¸§À» °¡Á®¿Í¼­ ¼­¹ö¿¡ ¼³Á¤
             string myName = SteamFriends.GetPersonaName();
             CmdSetDisplayName(myName);
-            // ë‚´ ì¹´ë©”ë¼ë§Œ êº¼ì£¼ê¸°
+            // ³» Ä«¸Ş¶ó¸¸ ²¨ÁÖ±â
             virtualCamera.gameObject.SetActive(true);
-            //ë Œë”ëŸ¬ ìš°ì„ ìˆœìœ„ +1
+            //·»´õ·¯ ¿ì¼±¼øÀ§ +1
             GetComponent<SpriteRenderer>().sortingOrder += 1;
         }
 
@@ -71,21 +71,21 @@ public class PlayerController : NetworkBehaviour
         m_wallSensorL1 = transform.Find("WallSensor_L1").GetComponent<Sensor_HeroKnight>();
         m_wallSensorL2 = transform.Find("WallSensor_L2").GetComponent<Sensor_HeroKnight>();
         attackPoint = transform.Find("AttackPoint").gameObject;
-        //attackPoint.SetActive(false); //ì•„ì´í…œ Use()ì—ì„œ Collider2D ì»´í¬ë„ŒíŠ¸ë¥¼ ë„ê³  í‚¤ëŠ”ì¤‘ 
+        //attackPoint.SetActive(false); //¾ÆÀÌÅÛ Use()¿¡¼­ Collider2D ÄÄÆ÷³ÍÆ®¸¦ ²ô°í Å°´ÂÁß 
     }
 
     /// <summary>
-    /// ì„œë²„ì— ì´ë¦„ì„ ì„¤ì •í•˜ë„ë¡ ìš”ì²­í•˜ëŠ” Command
+    /// ¼­¹ö¿¡ ÀÌ¸§À» ¼³Á¤ÇÏµµ·Ï ¿äÃ»ÇÏ´Â Command
     /// </summary>
     [Command]
     private void CmdSetDisplayName(string myName)
     {
-        // ì„œë²„ì—ì„œ ì´ë¦„ ì„¤ì • (SyncVarë¥¼ í†µí•´ ëª¨ë“  í´ë¼ì´ì–¸íŠ¸ì— ì „íŒŒë¨)
+        // ¼­¹ö¿¡¼­ ÀÌ¸§ ¼³Á¤ (SyncVar¸¦ ÅëÇØ ¸ğµç Å¬¶óÀÌ¾ğÆ®¿¡ ÀüÆÄµÊ)
         displayName = myName;
     }
 
     /// <summary>
-    /// ì´ë¦„ì´ ë³€ê²½ë  ë•Œ í˜¸ì¶œë˜ëŠ” Hook í•¨ìˆ˜
+    /// ÀÌ¸§ÀÌ º¯°æµÉ ¶§ È£ÃâµÇ´Â Hook ÇÔ¼ö
     /// </summary>
     private void OnDisplayNameChanged(string oldName, string newName)
     {
@@ -93,7 +93,7 @@ public class PlayerController : NetworkBehaviour
     }
 
     /// <summary>
-    /// ì„œë²„ì— í”Œë ˆì´ì–´ê°€ ë°”ë¼ë³´ëŠ” ë°©í–¥ì„ ì„¤ì •í•˜ë„ë¡ ìš”ì²­í•˜ëŠ” Command
+    /// ¼­¹ö¿¡ ÇÃ·¹ÀÌ¾î°¡ ¹Ù¶óº¸´Â ¹æÇâÀ» ¼³Á¤ÇÏµµ·Ï ¿äÃ»ÇÏ´Â Command
     /// </summary>
     /// <param name="direction"></param>
     [Command]
@@ -103,7 +103,7 @@ public class PlayerController : NetworkBehaviour
     }
 
     /// <summary>
-    /// ë°©í–¥ì´ ë³€ê²½ë  ë•Œ í˜¸ì¶œë˜ëŠ” Hook í•¨ìˆ˜
+    /// ¹æÇâÀÌ º¯°æµÉ ¶§ È£ÃâµÇ´Â Hook ÇÔ¼ö
     /// </summary>
     private void OnFacingDirectionChanged(int oldDirection, int newDirection)
     {
@@ -188,12 +188,12 @@ public class PlayerController : NetworkBehaviour
             m_animator.SetTrigger("Hurt");
 
         //Attack
-        //ì¥ë¹„ ì¥ì°©ì¤‘ì¸ì§€ ê²€ì‚¬ > ì¥ë¹„ ì•„ì´í…œì´ë¼ë©´ ì¥ë¹„ ì•„ì´í…œì˜ Useí˜¸ì¶œ
+        //Àåºñ ÀåÂøÁßÀÎÁö °Ë»ç > Àåºñ ¾ÆÀÌÅÛÀÌ¶ó¸é Àåºñ ¾ÆÀÌÅÛÀÇ UseÈ£Ãâ
         else if (Input.GetMouseButtonDown(0) && m_timeSinceAttack > 0.25f && !m_rolling)
         {
-            if (IsHandEquipped())  // ì†ì— ì¥ë¹„ ì¥ì°© ì—¬ë¶€ í™•ì¸
+            if (IsHandEquipped())  // ¼Õ¿¡ Àåºñ ÀåÂø ¿©ºÎ È®ÀÎ
             {
-                InventoryManager.Instance.slots[0].inventoryItem?.Use(this);  // ì¥ë¹„ì˜ Use() í˜¸ì¶œ
+                InventoryManager.Instance.slots[0].inventoryItem?.Use(this);  // ÀåºñÀÇ Use() È£Ãâ
 
 
                 m_currentAttack++;
@@ -261,7 +261,7 @@ public class PlayerController : NetworkBehaviour
         //Climb
         if (overlappingLadderCount > 0)
         {
-            vertical = Input.GetAxisRaw("Vertical"); // W, S ë˜ëŠ” â†‘, â†“ í‚¤ ê°ì§€
+            vertical = Input.GetAxisRaw("Vertical"); // W, S ¶Ç´Â ¡è, ¡é Å° °¨Áö
         }
     }
     void FixedUpdate()
@@ -269,16 +269,16 @@ public class PlayerController : NetworkBehaviour
         if (overlappingLadderCount > 0)
         {
             m_body2d.velocity = new Vector2(m_body2d.velocity.x, vertical * m_climbSpeed);
-            m_body2d.gravityScale = 0f; // ì¤‘ë ¥ ì œê±° (ì‚¬ë‹¤ë¦¬ì—ì„œ ë¶€ë“œëŸ½ê²Œ ì´ë™)
+            m_body2d.gravityScale = 0f; // Áß·Â Á¦°Å (»ç´Ù¸®¿¡¼­ ºÎµå·´°Ô ÀÌµ¿)
         }
         else
         {
-            m_body2d.gravityScale = 1f; // ë‹¤ì‹œ ì›ë˜ ì¤‘ë ¥ ë³µêµ¬
+            m_body2d.gravityScale = 1f; // ´Ù½Ã ¿ø·¡ Áß·Â º¹±¸
         }
     }
 
     /// <summary>
-    /// ì¥ì°©ëœ ì¥ë¹„ í™•ì¸
+    /// ÀåÂøµÈ Àåºñ È®ÀÎ
     /// </summary>
     private bool IsHandEquipped()
     {
@@ -308,7 +308,7 @@ public class PlayerController : NetworkBehaviour
     }
 
     /// <summary>
-    /// ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½È¯ : ï¿½Ú¿ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½ È£ï¿½ï¿½
+    /// ???? ???? ???? ?????? ??? : ??? ????????? ???
     /// </summary>
     public Item GetEquippedItem()
     {
@@ -321,9 +321,19 @@ public class PlayerController : NetworkBehaviour
 
         return null;
     }
+    /// <summary>
+    /// ¾ÆÀÌÅÛÀ» ´øÁı´Ï´Ù. ´øÁø ¾ÆÀÌÅÛÀº ¹Ù´Ú¿¡ ¶³¾îÁö¸ç ¹Ù´Ú¿¡ ¶³¾îÁø ¾ÆÀÌÅÛ µ¿±âÈ­µÊ
+    /// ÀÎº¥Åä¸®¿¡¼­ Á¦°ÅÇÏ´Â °Ç InventoryManager¿¡¼­ Ã³¸®
+    /// </summary>
+    [Command (requiresAuthority = false)]
+    public void ThrowItem(string itemCode)
+    {
+        // ¾ÆÀÌÅÛ µå·Ó
+        NetworkItemManager.Instance.SpawnItem(itemCode, transform.position, false);
+    }
 
     /// <summary>
-    /// ì„ì‹œ ê³µê²© íŒì •
+    /// ÀÓ½Ã °ø°İ ÆÇÁ¤
     /// </summary>
     /*
     private IEnumerator AttackPointEnable()
@@ -337,7 +347,7 @@ public class PlayerController : NetworkBehaviour
     {
         if (collision.CompareTag("Monster"))
         {
-            // ê³µê²© íŒì •
+            // °ø°İ ÆÇÁ¤
             //collision.GetComponent<Enemy>().TakeDamage(10);
             //StartCoroutine(AttackPointEnable());
         }

--- a/Assets/Scripts/Managers/ResourceRespawnManager.cs
+++ b/Assets/Scripts/Managers/ResourceRespawnManager.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 자원 리스폰을 담당하는 매니저 클래스
+/// </summary>
+public class ResourceRespawnManager : Singleton<ResourceRespawnManager>
+{
+    [Header("리스폰 시간 설정 (초)")]
+    [SerializeField] private float respawnDelayMin = 5f;
+    [SerializeField] private float respawnDelayMax = 6f;
+
+    /// <summary>
+    /// 자원 객체의 리스폰을 요청받는 함수
+    /// </summary>
+    public void RequestRespawn(GameObject resourceObject)
+    {
+        StartCoroutine(RespawnRoutine(resourceObject));
+    }
+
+    /// <summary>
+    /// 일정 시간 후 자원 오브젝트를 다시 활성화시키는 코루틴
+    /// </summary>
+    private IEnumerator RespawnRoutine(GameObject obj)
+    {
+        float delay = Random.Range(respawnDelayMin, respawnDelayMax);
+        yield return new WaitForSeconds(delay);
+
+        NetworkResource resource = obj.GetComponent<NetworkResource>();
+        if (resource != null)
+        {
+            resource.ResetResource();
+            resource.SetActiveState(true); // 서버에서 isActive 값을 true로 설정
+        }
+    }
+}

--- a/Assets/Scripts/Managers/ResourceRespawnManager.cs
+++ b/Assets/Scripts/Managers/ResourceRespawnManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// 자원 리스폰을 담당하는 매니저 클래스
+/// 자원 및 몬스터 리스폰을 담당하는 매니저 클래스
 /// </summary>
 public class ResourceRespawnManager : Singleton<ResourceRespawnManager>
 {
@@ -11,12 +11,24 @@ public class ResourceRespawnManager : Singleton<ResourceRespawnManager>
     [SerializeField] private float respawnDelayMin = 5f;
     [SerializeField] private float respawnDelayMax = 6f;
 
+    [Header("몬스터 리스폰 시간 설정 (초)")]
+    [SerializeField] private float monsterRespawnMin = 5f;
+    [SerializeField] private float monsterRespawnMax = 6f;
+
     /// <summary>
     /// 자원 객체의 리스폰을 요청받는 함수
     /// </summary>
     public void RequestRespawn(GameObject resourceObject)
     {
         StartCoroutine(RespawnRoutine(resourceObject));
+    }
+
+    /// <summary>
+    /// 몬스터 리스폰 요청
+    /// </summary>
+    public void RequestMonsterRespawn(GameObject monsterObject)
+    {
+        StartCoroutine(RespawnMonsterRoutine(monsterObject));
     }
 
     /// <summary>
@@ -32,6 +44,22 @@ public class ResourceRespawnManager : Singleton<ResourceRespawnManager>
         {
             resource.ResetResource();
             resource.SetActiveState(true); // 서버에서 isActive 값을 true로 설정
+        }
+    }
+
+    /// <summary>
+    /// 몬스터 리스폰 루틴
+    /// </summary>
+    private IEnumerator RespawnMonsterRoutine(GameObject obj)
+    {
+        float delay = Random.Range(monsterRespawnMin, monsterRespawnMax);
+        yield return new WaitForSeconds(delay);
+
+        obj.SetActive(true); // 반드시 먼저 활성화해야 함
+
+        if (obj.TryGetComponent(out MonsterController monster))
+        {
+            monster.ResetMonster(); //체력과 상태 초기화
         }
     }
 }

--- a/Assets/Scripts/Managers/ResourceRespawnManager.cs.meta
+++ b/Assets/Scripts/Managers/ResourceRespawnManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4e19616a6a3fbf418789788bdd6c004
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/Item/NetworkResource.cs
+++ b/Assets/Scripts/Network/Item/NetworkResource.cs
@@ -33,6 +33,23 @@ public class NetworkResource : NetworkBehaviour
     [Tooltip("이 자원에 피해를 줄 수 있는 도구 태그 (예: AXE, PICK)")]
     [SerializeField] private string toolTag = "AXE";
 
+
+    [SyncVar(hook = nameof(OnActiveStateChanged))]
+    private bool isActive = true;
+    /// <summary>
+    /// 서버에서 isActive를 설정하면 자동으로 모든 클라이언트에서 OnActiveStateChanaged() 호출되어 SetActive를 반영시킴
+    /// </summary>
+    private void OnActiveStateChanged(bool oldValue, bool newValue)
+    {
+        gameObject.SetActive(newValue);
+    }
+
+    [Server]
+    public void SetActiveState(bool state)
+    {
+        isActive = state; // SyncVar을 통해 모든 클라이언트에게 반영됨
+    }
+
     void Start()
     {
         healthBar.fillAmount = 1;
@@ -69,8 +86,14 @@ public class NetworkResource : NetworkBehaviour
             // 아이템 드롭
             DropItem();
 
+            // 리스폰 매니저에 비활성화 + 재활성 요청
+            ResourceRespawnManager.Instance.RequestRespawn(gameObject);
+
+            isActive = false;
+
+
             // 자원 오브젝트 파괴
-            NetworkServer.Destroy(gameObject);
+            //NetworkServer.Destroy(gameObject);
         }
     }
 
@@ -136,6 +159,22 @@ public class NetworkResource : NetworkBehaviour
                 CmdHitResource(tool.damage); // 피해량 전달
             }
         }
+    }
+
+    /// <summary>
+    /// 자원 재활성화 시 상태 초기화
+    /// </summary>
+    [Server]
+    public void ResetResource()
+    {
+        currentHealth = resourceHealth;
+
+        // 체력바 초기화
+        healthBar.fillAmount = 1f;
+
+        // 체력바 UI 비활성화 (체력이 모두 찬 상태로 시작)
+        if (healthBarBG != null)
+            healthBarBG.SetActive(false);
     }
 }
 /// <summary>


### PR DESCRIPTION
- HandyTool이 attackPoint 게임 오브젝트 자체를 끄고 키도록 변경
- 레벨 디자인 씬 왼쪽에 한번 떨어지면 다시 못 올라오는 거 수정
- 동물들이 너무 자유롭게 돌아다니지 못하도록 일단 플랫폼끼리 끊어 놓음 
- 자원 및 몬스터 죽음 방식을 Destroy에서 SetActive 끄고 키고로 변경 >> 리스포너가 다시 스폰 시키도록 함 