### PR TITLE
[Fix] 건설 및 업그레이드 시 클라이언트가 자원을 소모하도록 수정

### DIFF
--- a/Assets/Scripts/Managers/BuildManager.cs
+++ b/Assets/Scripts/Managers/BuildManager.cs
@@ -352,11 +352,11 @@ public class BuildManager : NetworkBehaviour
     {
         if (_selectRoom.IsEmptyRoom)
         {
-            CmdBuildRoom(coordinate);
+            CheckAndBuildRoom(coordinate);
         }
         else
         {
-            BuildUpgradeManager.Instance.CmdRoomUpgrade(coordinate);
+            BuildUpgradeManager.Instance.CheckAndUpgradeRoom(coordinate);
         }
     }
 
@@ -364,8 +364,7 @@ public class BuildManager : NetworkBehaviour
     /// A method that constructs a building at the given coordinates.
     /// </summary>
     /// <param name="coordinate"></param>
-    [Command(requiresAuthority = false)]
-    public void CmdBuildRoom(Vector2Int coordinate)
+    public void CheckAndBuildRoom(Vector2Int coordinate)
     {
         // 새 방 생성
         if (!CanBuildRoom(coordinate))
@@ -378,17 +377,23 @@ public class BuildManager : NetworkBehaviour
         }
         else
         {
-            if (coordinate.y == 0)
-            {
-                BuildRoom(0, coordinate);
-            }
-            else
-            {
-                BuildRoom(1, coordinate);
-            }
             UseRequiredItem(_selectRoom);
+            CmdBuildRoom(coordinate);
         }
 
+    }
+
+    [Command(requiresAuthority = false)]
+    private void CmdBuildRoom(Vector2Int coordinate)
+    {
+        if (coordinate.y == 0)
+        {
+            BuildRoom(0, coordinate);
+        }
+        else
+        {
+            BuildRoom(1, coordinate);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/BuildUpgradeManager.cs
+++ b/Assets/Scripts/Managers/BuildUpgradeManager.cs
@@ -27,8 +27,7 @@ public class BuildUpgradeManager : NetworkBehaviour
     /// </summary>
     /// <param name="coordinate"></param>
     /// <param name="upgradeRoom"></param>
-    [Command(requiresAuthority = false)]
-    public void CmdRoomUpgrade(Vector2Int coordinate)
+    public void CheckAndUpgradeRoom(Vector2Int coordinate)
     {
         if (!CheckUpgradableRoom(coordinate))
         {
@@ -43,8 +42,14 @@ public class BuildUpgradeManager : NetworkBehaviour
             // 업그레이드 가능 조건 충족 시 
             // 자원 소모 후 방 업그레이드
             BuildManager.Instance.UseRequiredItem(_selectRoom);
-            ReplaceRoom(coordinate, _selectRoom);
+            CmdUpgradeRoom(coordinate);
         }
+    }
+
+    [Command(requiresAuthority = false)]
+    private void CmdUpgradeRoom(Vector2Int coordinate)
+    {
+        ReplaceRoom(coordinate, _selectRoom);
     }
 
     /// <summary>


### PR DESCRIPTION
- 건설 및 업그레이드 가능 조건 확인과 자원 소모를 [Command]로 수행하도록 되어있어서 방장의 자원을 소모하고 있던 버그를 클라이언트에서 이루어지도록 수정